### PR TITLE
Replace `window` with `globalThis`

### DIFF
--- a/.changeset/quick-hotels-hammer.md
+++ b/.changeset/quick-hotels-hammer.md
@@ -1,0 +1,5 @@
+---
+"browser-namespace": minor
+---
+
+Fix: use globalThis instead of window.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,11 @@
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export type Browser = typeof import("webextension-polyfill");
 
-// @ts-expect-error Ignoring missing window type.
-export const browser: Browser = window.browser ?? window.chrome;
+// @ts-expect-error Ignoring missing globalThis type.
+export const browser: Browser = globalThis.browser ?? globalThis.chrome;
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
 export type Chrome = import("./chrome-types/index.d.ts").Chrome;
 
-// @ts-expect-error Ignoring missing window type.
-export const chrome: Chrome = window.chrome ?? window.browser;
+// @ts-expect-error Ignoring missing globalThis type.
+export const chrome: Chrome = globalThis.chrome ?? globalThis.browser;


### PR DESCRIPTION
This pull request replaces the usage of the `window` object with `globalThis` in the codebase. This change ensures compatibility with different JavaScript environments (e.g. service workers) and improves code portability.